### PR TITLE
Tables now self-balance, added Remove, updated prelude, and overloaded Empty? and Index

### DIFF
--- a/builtins.js
+++ b/builtins.js
@@ -304,11 +304,6 @@ export const Builtins = {
     returns: 'boolean',
     fn: (a, b) => _compare(a, b) == 0,
   },
-  "!=": {
-    params: [{name: 'operand', type: 'any'}, {name: 'operand', type: 'any'}],
-    returns: 'boolean',
-    fn: (a, b) => _compare(a, b) != 0,
-  },
   ">": {
     params: [{name: 'operand', type: 'number'}, {name: 'operand', type: 'number'}],
     returns: 'boolean',

--- a/builtins.js
+++ b/builtins.js
@@ -499,6 +499,19 @@ export const Builtins = {
       return table_insert(key, value, table.table);
     }
   },
+  Remove: {
+    params: [
+      {name: 'key', type: 'any'},
+      {name: 'table', type: 'table'},
+    ],
+    returns: 'table',
+    fn: (key, table) => {
+      if (['box', 'block'].includes(key.type)) {
+        return {error: `can't index table with ${key.type}`};
+      }
+      return table_remove(key, table.table);
+    }
+  },
   Has: {
     params: [{name: 'key', type: 'any'}, {name: 'table', type: 'table'}],
     returns: 'boolean',
@@ -549,26 +562,47 @@ function table_entries(table) {
   return l;
 }
 
+function mktable(key, value, left, right, level)
+{
+  let T = Object.create(null);
+  T.key = key;
+  T.value = value;
+  T.left = left;
+  T.right = right;
+  T.level = level;
+  return T;
+}
+
 function table_get(key, table) {
   if (!table) return;
   if (_compare(key, table.key) == 0) return table.value;
   return table_get(key, table.left) || table_get(key, table.right);
 }
 
+function table_skew(T) {
+  if (!T) return null;
+  else if (!T.left) return T;
+  else if (T.left.level == T.level)
+    return mktable(T.left.key, T.left.value, T.left.left,
+        mktable(T.key, T.value, T.left.right, T.right, T.level),
+        T.left.level);
+  else return T;
+}
+
+function table_split(T)
+{
+  if (!T) return null;
+  else if (!T.right || !T.right.right) return T;
+  else if (T.level == T.right.right.level)
+    return mktable(T.right.key, T.right.value,
+        mktable(T.key, T.value, T.left, T.right.left, T.level),
+        T.right.right, T.right.level);
+  else return T;
+}
+
 function table_insert(key, value, table)  {
-  if (!table) {
-    let T = Object.create(null);
-    T.key = key;
-    T.value = value;
-    T.level = 1;
-    return T;
-  }
-  let T = Object.create(null);
-  T.key = table.key;
-  T.value = table.value;
-  T.left = table.left;
-  T.right = table.right;
-  T.level = table.level;
+  if (!table) return mktable(key, value, null, null, 1);
+  let T = mktable(table.key, table.value, table.left, table.right, table.level);
   switch (_compare(table.key, key)) {
     case 0:
       T.key = key;
@@ -580,7 +614,64 @@ function table_insert(key, value, table)  {
     default:
       T.right = table_insert(key, value, table.right);
   }
+  T = table_skew(T);
+  T = table_split(T);
   return T;
+}
+
+function table_remove(key, T) {
+  if (!T) return { error: `${cognate2string(key).value} is not in table`, };
+  let diff = _compare(T.key, key);
+  let T2 = null;
+
+  if (diff < 0) {
+    let N = table_remove(key, T.right);
+    if (N && N.error) return N;
+    T2 = mktable(T.key, T.value, T.left, N, T.level);
+  }
+  else if (diff > 0) {
+    let N = table_remove(key, T.left);
+    if (N && N.error) return N;
+    T2 = mktable(T.key, T.value, N, T.right, T.level);
+  }
+  else if (!T.left && !T.right) return null;
+  else if (!T.left) {
+      let L = T.right;
+      while (L.left) L = L.left;
+      let N = table_remove(L.key, T.right);
+      if (N && N.error) return N;
+      T2 = mktable(L.key, L.value, T.left, N, L.level);
+  }
+  else {
+      let L = T.left;
+      while (L.right) L = L.right;
+      let N = table_remove(L.key, T.left);
+      if (N && N.error) return N;
+      T2 = mktable(L.key, L.value, N, T.right, L.level);
+  }
+
+  if (T2.left && T2.right) {
+    let should_be = 1 + Math.min(T2.left.level, T2.right.level);
+    if (should_be < T2.level) {
+      T2.level = should_be;
+      if (should_be < T2.right.level) T2.right.level = should_be
+    }
+  }
+
+  /*
+  if (T2.right) {
+    T2.right.right = table_skew(T2.right.right);
+    T2.right = table_skew(T2.right);
+  }
+  */
+
+  T2 = table_skew(T2);
+
+  //if (T2.right) T2.right = table_split(T2.right);
+
+  T2 = table_split(T2);
+
+  return T2;
 }
 
 export function initIdent2kind(preludeEnv) {

--- a/builtins.js
+++ b/builtins.js
@@ -397,9 +397,23 @@ export const Builtins = {
     fn: () => [],
   },
   "Empty?": {
-    params: [{name: 'list', type: 'list'}],
-    returns: 'boolean',
-    fn: (l) => l.list.length == 0,
+		overloads: [
+		{
+			params: [{name: 'list', type: 'list'}],
+			returns: 'boolean',
+			fn: (l) => l.list.length == 0,
+		},
+		{
+			params: [{name: 'string', type: 'string'}],
+			returns: 'boolean',
+			fn: (s) => s.value === "",
+		},
+		{
+			params: [{name: 'table', type: 'table'}],
+			returns: 'boolean',
+			fn: (t) => !t.table,
+		},
+		]
   },
   Length: {
     overloads: [

--- a/public/prelude.cog
+++ b/public/prelude.cog
@@ -1,4 +1,14 @@
 ~
+Compares two values and returns True if they differ.
+
+```
+Print != 1 2;
+Print != 1 1;
+```
+~
+Def != as ( Not == );
+
+~
 Discard the top stack item.
 
 ```
@@ -139,7 +149,7 @@ With \read "foo.txt" (
 );
 ```
 ~
-~Def With (
+Def With (
 	Let Mode be Of (Symbol?);
 	Let Filename be Of (String?);
 	Def Body;
@@ -147,7 +157,6 @@ With \read "foo.txt" (
 	Body Fp;
 	Close Fp
 );
-~
 
 ~
 Returns the list parameter reversed.
@@ -157,8 +166,14 @@ Print Reverse List (1 2 3);
 ```
 ~
 Def Reverse (
-	Fold ( Push ) from Empty over List!;
-);
+	Def Reverse-helper (
+		Let L1 be List!;
+		Let L2 be List!;
+		Do If Empty? L2 ( L1 ) else ( Reverse-helper Push First L2 to L1 and Rest L2 )
+	);
+
+	Reverse-helper Empty;
+)
 
 ~
 Takes a block (`F`) and a list (`L`) as parameters. Applies a block to each element in a list
@@ -221,14 +236,19 @@ Print;
 ~
 Def Filter (
 	Def Predicate;
-	Let L be Of (List?);
-   Empty;
-	For each in L (
-		Let I;
-		Let R be Predicate I;
-		When R ( Push I );
+
+	Def Filter-helper (
+		Let Acc be List!;
+		Let L be List!;
+		Do If Empty? L ( Acc )
+		else (
+			Let R be Boolean! Predicate First L;
+			Do If R ( Filter-helper Push First L to Acc and Rest L )
+			   else ( Filter-helper Acc and Rest L );
+		)
 	);
-	Reverse;
+
+	Reverse Filter-helper Empty;
 );
 
 ~
@@ -394,15 +414,18 @@ Print
 ~
 Def Map (
 	Def F;
-	Let L be a List!;
 
-	Do If Empty? L ( L )
-	else (
-		Let X be First of L;
-		Let Res be F X;
-
-		return Push Res to Map (F) over Rest of L;
+	Def Map-helper (
+		Let Acc be List!;
+		Let L be List!;
+		Do If Empty? L ( Acc )
+		else (
+			Let R be F of First L;
+			Map-helper Push R to Acc and Rest L
+		)
 	);
+
+	Reverse Map-helper Empty;
 );
 
 ~
@@ -429,17 +452,22 @@ Print Take 4 from Range 1 to 10;
 ```
 ~
 Def Take (
-	Let N be Of (Integer?);
-	Let L be Of (List?);
-
-	Do If Zero? N ( Empty list ) else (
-		When Empty? L ( Error "Cannot Take more elements than in list" );
-		Push First L to Take - 1 N from Rest of L
+	Def Take-helper (
+		Let Acc be List!;
+		Let N be Number!;
+		Let L be List!;
+		Do If Zero? N ( Acc )
+		else (
+			When Empty? L ( Error "Cannot Take more elements than in list" );
+			Take-helper Push First L to Acc taking - 1 N from Rest L;
+		)
 	);
+
+	Reverse Take-helper Empty;
 );
 
 ~
-Takes an integer (`N`) and a list (`L`) as parameters. Returns the `N`th element (indexed from zero) of `L`.
+Takes an integer (`N`) and a list or string (`L`) as parameters. Returns the `N`th element (indexed from zero) of `L`.
 
 ```
 Print Index 4 of Range 0 to 100;
@@ -447,13 +475,13 @@ Print Index 4 of Range 0 to 100;
 ~
 Def Index (
 	Let N be Of (Integer?);
-	Let L be List!;
+	Let L;
 
 	When < 0 N ( Error Join "Invalid index " Show N );
 
 	Do If Zero? N ( return First element of L )
 	else (
-		When Empty? L ( Error "Index is beyond end of list" );
+		When Empty? L ( Error "Index is beyond the end" );
 		Index - 1 N of Rest of L
 	);
 );
@@ -474,11 +502,15 @@ Def Range (
 		Error Join Join Join "Invalid range " Show Start "..." Show End;
 	);
 
-	Reverse List (
-		Start;
-		While (Triplet ; < End) ( + 1 );
-		Drop; Drop;
-	)
+	Def Range-helper (
+		Let Start be Number!;
+		Let End be Number!;
+		Let L be List!;
+
+		Do If < End Start ( Range-helper from + 1 Start to End with Push Start to L ) else ( L );
+	);
+
+	Reverse Range-helper from Start to End with Empty;
 );
 
 ~

--- a/public/prelude.cog
+++ b/public/prelude.cog
@@ -478,12 +478,10 @@ Def Index (
 	Let L;
 
 	When < 0 N ( Error Join "Invalid index " Show N );
+	When Empty? L ( Error "Index is beyond the end" );
 
 	Do If Zero? N ( return First element of L )
-	else (
-		When Empty? L ( Error "Index is beyond the end" );
-		Index - 1 N of Rest of L
-	);
+	else ( Index - 1 N of Rest of L );
 );
 
 ~


### PR DESCRIPTION
- Added table_remove, table_split, and table_skew which mirror the functionality in cognac's runtime.
- Updated the prelude to use the tail recursive definitions.
- More generic Index that works with strings also. 
- Moved != from builtins to prelude, defining it as Not ==.
- Overloaded Empty? to check for empty strings and tables.